### PR TITLE
Check the string length before doing substring

### DIFF
--- a/bio-as-utils.scm
+++ b/bio-as-utils.scm
@@ -52,10 +52,12 @@
       fn))
 
 (define (string-starts-with? str prefix)
-  (let* ((start 0)
-         (end (string-length prefix))
-         (str-prefix (substring str start end)))
-    (equal? str-prefix prefix)))
+  (if (< (string-length str) (string-length prefix))
+    #f
+    (let* ((start 0)
+           (end (string-length prefix))
+           (str-prefix (substring str start end)))
+      (equal? str-prefix prefix))))
 
 (define (smp? A)
   (and (eq? (cog-type A) 'ConceptNode)


### PR DESCRIPTION
Happen to find names shorter than the prefix length in the KBs..